### PR TITLE
Change config file default (hihtml.config.json)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to hihtml are documented in this file, which is (mostly) AI-
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/), and the project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.4.0] - 2026-07-11
+
+### Changed
+
+* Renamed the default settings file from .hihtml.json to hihtml.config.json, following the “<tool>.config” convention (.hihtml.json remains supported as a fallback, so existing setups keep working)
+
 ## [1.3.4] - 2026-07-01
 
 ### Changed

--- a/README.md
+++ b/README.md
@@ -192,11 +192,11 @@ Minifies an HTML string using HTML Minifier Next. Returns `Promise<string>`. Use
 
 #### `loadConfig(cwd?, filePath?)`
 
-Loads hihtml configuration. When `filePath` is given, only that file is read (no CWD fallback); if it contains a `"hihtml"` key that value is used, otherwise the root object is used. Without `filePath`, reads `.hihtml.json` or the `"hihtml"` key in `package.json` from `cwd`. Returns `Promise<HihtmlConfig>`.
+Loads hihtml configuration. When `filePath` is given, only that file is read (no CWD fallback); if it contains a `"hihtml"` key that value is used, otherwise the root object is used. Without `filePath`, reads hihtml.config.json or the `"hihtml"` key in package.json from `cwd`. Returns `Promise<HihtmlConfig>`.
 
 ## Configuration
 
-Create a .hihtml.json file in your project root, or add a `"hihtml"` key to package.json. Both use the same format (here showing hihtml’s defaults):
+Create a hihtml.config.json file in your project root, or add a `"hihtml"` key to package.json. Both use the same format (here showing hihtml’s defaults):
 
 ```json
 {
@@ -218,7 +218,7 @@ Create a .hihtml.json file in your project root, or add a `"hihtml"` key to pack
 }
 ```
 
-.hihtml.json takes precedence over package.json when both are present.
+hihtml.config.json takes precedence over package.json when both are present.
 
 ## Exit Codes
 

--- a/bin/hihtml.test.js
+++ b/bin/hihtml.test.js
@@ -1241,8 +1241,20 @@ describe('Load config', () => {
     fs.rmdirSync(configDir);
   });
 
-  test('Loads .hihtml.json', async () => {
+  test('Loads hihtml.config.json', async () => {
     const configDir = path.join(tempDir, 'withconfig');
+    fs.mkdirSync(configDir, { recursive: true });
+    fs.writeFileSync(
+      path.join(configDir, 'hihtml.config.json'),
+      JSON.stringify({ validation: { preset: 'standard' } })
+    );
+    const config = await loadConfig(configDir);
+    assert.strictEqual(config.validation?.preset, 'standard');
+    fs.rmSync(configDir, { recursive: true, force: true });
+  });
+
+  test('Loads .hihtml.json (former name, still supported)', async () => {
+    const configDir = path.join(tempDir, 'withlegacyconfig');
     fs.mkdirSync(configDir, { recursive: true });
     fs.writeFileSync(
       path.join(configDir, '.hihtml.json'),
@@ -1250,6 +1262,16 @@ describe('Load config', () => {
     );
     const config = await loadConfig(configDir);
     assert.strictEqual(config.validation?.preset, 'standard');
+    fs.rmSync(configDir, { recursive: true, force: true });
+  });
+
+  test('hihtml.config.json takes precedence over .hihtml.json', async () => {
+    const configDir = path.join(tempDir, 'bothfileconfig');
+    fs.mkdirSync(configDir, { recursive: true });
+    fs.writeFileSync(path.join(configDir, 'hihtml.config.json'), JSON.stringify({ validation: { preset: 'a11y' } }));
+    fs.writeFileSync(path.join(configDir, '.hihtml.json'), JSON.stringify({ validation: { preset: 'standard' } }));
+    const config = await loadConfig(configDir);
+    assert.strictEqual(config.validation?.preset, 'a11y');
     fs.rmSync(configDir, { recursive: true, force: true });
   });
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "hihtml",
-  "version": "1.3.4",
+  "version": "1.4.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "hihtml",
-      "version": "1.3.4",
+      "version": "1.4.0",
       "license": "MIT",
       "dependencies": {
         "commander": "^15.0.0",

--- a/package.json
+++ b/package.json
@@ -55,5 +55,5 @@
   },
   "type": "module",
   "types": "src/index.d.ts",
-  "version": "1.3.4"
+  "version": "1.4.0"
 }

--- a/src/lib/config.js
+++ b/src/lib/config.js
@@ -1,7 +1,8 @@
 import fs from 'node:fs';
 import path from 'node:path';
 
-const CONFIG_FILE = '.hihtml.json';
+// Looked up in this order, honoring past config file names
+const CONFIG_FILES = ['hihtml.config.json', '.hihtml.json'];
 
 /**
  * @param {unknown} config
@@ -62,7 +63,32 @@ function validateConfig(config, source) {
  */
 
 /**
- * Load configuration from a specific file, .hihtml.json, or the `"hihtml"` key in package.json.
+ * Reads and validates one config file from `cwd`, returning `undefined` when
+ * the file doesn’t exist (so the caller can try the next name).
+ * @param {string} cwd
+ * @param {string} fileName
+ * @returns {Promise<HihtmlConfig | undefined>}
+ */
+async function readConfigFile(cwd, fileName) {
+  const configPath = path.join(cwd, fileName);
+  let parsed;
+  try {
+    const content = await fs.promises.readFile(configPath, 'utf8');
+    parsed = JSON.parse(content);
+  } catch (err) {
+    const nodeErr = /** @type {NodeJS.ErrnoException} */ (err);
+    if (nodeErr.code !== 'ENOENT') throw new Error(`Error reading ${fileName}: ${nodeErr.message}`, { cause: err });
+    return undefined;
+  }
+  if (parsed === null || typeof parsed !== 'object' || Array.isArray(parsed)) {
+    throw new Error(`${fileName} must contain a JSON object`);
+  }
+  validateConfig(parsed, fileName);
+  return parsed;
+}
+
+/**
+ * Load configuration from a specific file, hihtml.config.json, or the `"hihtml"` key in package.json.
  * When `filePath` is given, only that file is read (no CWD fallback).
  * If the file contains a `"hihtml"` key, that key’s value is used; otherwise the root object is used.
  * @param {string} [cwd]
@@ -93,21 +119,9 @@ export async function loadConfig(cwd = process.cwd(), filePath = undefined) {
     return parsed;
   }
 
-  const configPath = path.join(cwd, CONFIG_FILE);
-  let parsed;
-  try {
-    const content = await fs.promises.readFile(configPath, 'utf8');
-    parsed = JSON.parse(content);
-  } catch (err) {
-    const nodeErr = /** @type {NodeJS.ErrnoException} */ (err);
-    if (nodeErr.code !== 'ENOENT') throw new Error(`Error reading ${CONFIG_FILE}: ${nodeErr.message}`, { cause: err });
-  }
-  if (parsed !== undefined) {
-    if (parsed === null || typeof parsed !== 'object' || Array.isArray(parsed)) {
-      throw new Error(`${CONFIG_FILE} must contain a JSON object`);
-    }
-    validateConfig(parsed, CONFIG_FILE);
-    return parsed;
+  for (const fileName of CONFIG_FILES) {
+    const parsed = await readConfigFile(cwd, fileName);
+    if (parsed !== undefined) return parsed;
   }
 
   const pkgPath = path.join(cwd, 'package.json');


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for `hihtml.config.json` as the default configuration filename.
  * Continued support for `.hihtml.json` as a legacy fallback.
  * Configuration now prioritizes `hihtml.config.json` when multiple supported files are present.

* **Documentation**
  * Updated configuration-loading API documentation and release notes.

* **Bug Fixes**
  * Improved handling and reporting of invalid configuration files.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->