### PR TITLE
Improve input validation and error handling

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,17 @@ All notable changes to hihtml are documented in this file, which is (mostly) AI-
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/), and the project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.6.0] - 2026-08-13
+
+### Fixed
+
+* Ensured to fail with a message and a non-zero exit when the input path doesn’t exist or can’t be read; a scripted run pointing at a mistyped path now fails instead of passing
+
+### Changed
+
+* Changed an unusable setting or an unreadable settings file to exit `1`, like every other input hihtml can’t work with; `2` is now reserved for a run that fails on its own, such as a checker that can’t be loaded
+* Renamed the positional argument to `path` in the help output, matching that it takes a directory or a single file
+
 ## [1.5.0] - 2026-08-12
 
 ### Added
@@ -45,7 +56,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 ### Changed
 
-* Clarified in documentation that ObsoHTML warnings are informational (and exit “0”)
+* Clarified in documentation that ObsoHTML warnings are informational (and exit `0`)
 
 ## [1.3.1-beta] - 2026-05-14
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -92,10 +92,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 * Added `validation.ignore`, a list of HTML-validate rule IDs to suppress, mirroring `links.ignore`
   - Ignored messages appear in validation output (marked as ignored) but are not counted as errors and do not block minification when using `--all`/`-a`
-  - Supported in configuration (`.hihtml.json`/`package.json`) and programmatically via `checkCode(files, { ignore: […] })`
+  - Supported in configuration (.hihtml.json/package.json) and programmatically via `checkCode(files, { ignore: […] })`
   - `ResultCodeValidation` now includes `countIgnored`; `MessageValidation` now includes `ignored?: boolean`
 * Added `-s`/`--settings <file>` flag to load configuration from a specific JSON file, overriding the default CWD config lookup
-  - Accepts any JSON file, reading the `"hihtml"` key if present (same convention as `package.json`), otherwise using the root object
+  - Accepts any JSON file, reading the `"hihtml"` key if present (same convention as package.json), otherwise using the root object
   - `loadConfig()` now accepts an optional `filePath` parameter for the same behavior programmatically
 * Added `-q`/`--quiet` flag to suppress all output when no issues are found, for cleaner CI and script usage
 * Enhanced progress indicators to show a color-coded dot: blue while processing, green on completion when no issues are found, yellow when issues are found

--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ Without options, hihtml validates HTML files and checks for deprecated markup in
 | `-o`, `--output <dir>` | Output directory for minification |
 | `-s`, `--settings <file>` | Load configuration from a specific JSON file (overrides CWD config lookup) |
 | `-q`, `--quiet` | Suppress output when no issues are found |
-| `-r`, `--report [file]` | Save a JSON report (default: `hihtml-report.json`) |
+| `-r`, `--report [file]` | Save a JSON report (default: hihtml-report.json) |
 | `-v`, `--version` | Show version number |
 | `-h`, `--help` | Show help |
 

--- a/README.md
+++ b/README.md
@@ -228,14 +228,14 @@ hihtml.config.json takes precedence over package.json when both are present.
 | Code | Meaning |
 |---|---|
 | `0` | No issues found (ObsoHTML warnings on deprecated markup are informational) |
-| `1` | Validation errors, broken links, or minification errors found |
-| `2` | Tool or runtime error |
+| `1` | Validation errors, broken links, or minification errors found—or an input hihtml can’t work with, like a path that isn’t there, a `--report` value that isn’t a `.json` filename, or an unusable setting |
+| `2` | A run that failed on its own, like a checker that couldn’t be loaded |
 
 ## FAQ
 
 ### How do I only run select checks?
 
-Use the individual flags (`-c`, `-l`, `-m`) instead of `--all`/`-a`. Each flag only exits “1” for issues within its own scope, so you control exactly what affects the exit code. To suppress specific HTML-validate rule IDs without disabling validation entirely, use `validation.ignore` in your configuration. To suppress specific broken links without skipping link checking altogether, use `links.ignore`.
+Use the individual flags (`-c`, `-l`, `-m`) instead of `--all`/`-a`. Each flag only exits `1` for issues within its own scope, so you control exactly what affects the exit code. To suppress specific HTML-validate rule IDs without disabling validation entirely, use `validation.ignore` in your configuration. To suppress specific broken links without skipping link checking altogether, use `links.ignore`.
 
 ### Where do I report issues?
 

--- a/bin/hihtml.js
+++ b/bin/hihtml.js
@@ -28,7 +28,7 @@ program
   .option('-l, --check-links', 'check all external http/https URLs for broken references')
   .option('-m, --minify', 'minify HTML files (in-place unless `--output` is set)')
   .option('-a, --all', 'check HTML code and links, then minify if no validation errors (built-in conformance gate—different from using all individual flags together)')
-  .argument('[dir]', 'input directory, or a single file (default: current directory)')
+  .argument('[path]', 'input directory, or a single file (default: current directory)')
   .option('-i, --input <dir>', 'input directory (alternative to the positional argument)', '.')
   .option('-o, --output <dir>', 'output directory for minification (default: same as input)')
   .option('-s, --settings <file>', 'load configuration from a specific JSON file (overrides CWD config lookup)')
@@ -67,6 +67,21 @@ if (inputPositional) {
     process.exit(1);
   }
   opts.input = inputPositional;
+}
+
+let inputStats;
+try {
+  inputStats = fs.statSync(opts.input);
+} catch {
+  console.error(styleText('red', `No such file or directory: ${opts.input}`));
+  process.exit(1);
+}
+
+try {
+  fs.accessSync(opts.input, inputStats.isDirectory() ? fs.constants.R_OK | fs.constants.X_OK : fs.constants.R_OK);
+} catch {
+  console.error(styleText('red', `Cannot read ${opts.input}`));
+  process.exit(1);
 }
 
 // The hint below is meant to be copied, so a path holding whitespace is quoted
@@ -286,7 +301,7 @@ function makeProgress(label, total, { leadingNewline = false } = {}) {
   } catch (err) {
     if (process.stderr.isTTY) process.stderr.write('\n');
     console.error(style.error(`Error: ${err instanceof Error ? err.message : String(err)}`));
-    process.exit(2);
+    process.exit(err?.setupFailed ? 1 : 2);
   }
 })();
 

--- a/bin/hihtml.js
+++ b/bin/hihtml.js
@@ -72,8 +72,13 @@ if (inputPositional) {
 let inputStats;
 try {
   inputStats = fs.statSync(opts.input);
-} catch {
-  console.error(styleText('red', `No such file or directory: ${opts.input}`));
+} catch (err) {
+  // A parent directory without search permission fails here, too, for a path
+  // that may well be there
+  const reason = err.code === 'ENOENT' || err.code === 'ENOTDIR'
+    ? `No such file or directory: ${opts.input}`
+    : `Cannot read ${opts.input}`;
+  console.error(styleText('red', reason));
   process.exit(1);
 }
 

--- a/bin/hihtml.test.js
+++ b/bin/hihtml.test.js
@@ -160,6 +160,22 @@ describe('CLI flags', () => {
     }
   });
 
+  // `statSync` fails with `EACCES` here, for an input that is nonetheless there
+  test('Fails on an input whose parent cannot be searched', { skip: !canTestPermissions }, () => {
+    const dirParent = path.join(tempDir, 'locked_parent');
+    const dirChild = path.join(dirParent, 'child');
+    fs.mkdirSync(dirChild, { recursive: true });
+    fs.chmodSync(dirParent, 0o000);
+    try {
+      const { stderr, status } = run([dirChild]);
+      assert.match(stderr, /Cannot read/);
+      assert.strictEqual(status, 1);
+    } finally {
+      fs.chmodSync(dirParent, 0o755);
+      fs.rmSync(dirParent, { recursive: true, force: true });
+    }
+  });
+
   test('`-c -m` runs check and minify', () => {
     const outDir = path.join(tempDir, 'cm_out');
     const { stdout, status } = run(['-c', '-m', '-i', path.join(tempDir, 'clean.html'), '-o', outDir]);

--- a/bin/hihtml.test.js
+++ b/bin/hihtml.test.js
@@ -18,6 +18,9 @@ const __dirname = path.dirname(fileURLToPath(import.meta.url));
 const scriptPath = path.join(__dirname, 'hihtml.js');
 const tempDir = path.join(__dirname, 'temp_test');
 
+// Permission bits don’t apply to root, and `chmod` is a no-op on Windows
+const canTestPermissions = process.platform !== 'win32' && process.getuid?.() !== 0;
+
 function run(args, stdinInput = '', cwd = undefined) {
   const result = spawnSync('node', [scriptPath, ...args], {
     encoding: 'utf-8',
@@ -128,6 +131,33 @@ describe('CLI flags', () => {
     assert.ok(stdout.includes('--check-code'));
     assert.ok(stdout.includes('--minify'));
     assert.strictEqual(status, 0);
+  });
+
+  // A path that isn’t there used to collect no files and exit `0`, reading as a clean run
+  test('Fails on a path that does not exist', () => {
+    const { stderr, status } = run([path.join(tempDir, 'nonexistent')]);
+    assert.match(stderr, /No such file or directory/);
+    assert.strictEqual(status, 1);
+  });
+
+  test('Fails on a `--input` path that does not exist', () => {
+    const { stderr, status } = run(['-i', path.join(tempDir, 'nonexistent')]);
+    assert.match(stderr, /No such file or directory/);
+    assert.strictEqual(status, 1);
+  });
+
+  test('Fails on a directory it cannot read', { skip: !canTestPermissions }, () => {
+    const dirLocked = path.join(tempDir, 'locked_input');
+    fs.mkdirSync(dirLocked, { recursive: true });
+    fs.chmodSync(dirLocked, 0o000);
+    try {
+      const { stderr, status } = run([dirLocked]);
+      assert.match(stderr, /Cannot read/);
+      assert.strictEqual(status, 1);
+    } finally {
+      fs.chmodSync(dirLocked, 0o755);
+      fs.rmSync(dirLocked, { recursive: true, force: true });
+    }
   });
 
   test('`-c -m` runs check and minify', () => {
@@ -246,7 +276,7 @@ describe('CLI flags', () => {
 // CLI: Check code (validate)
 
 describe('CLI `--check-code`', () => {
-  test('Exits “0” when no HTML files are found', () => {
+  test('Exits `0` when no HTML files are found', () => {
     const emptyDir = path.join(tempDir, 'empty');
     fs.mkdirSync(emptyDir, { recursive: true });
     const { status } = run(['-c', '-i', emptyDir]);
@@ -269,17 +299,17 @@ describe('CLI `--check-code`', () => {
     assert.ok(stdout.includes('center'));
   });
 
-  test('Exits “1” when deprecated markup is found', () => {
+  test('Exits `1` when deprecated markup is found', () => {
     const { status } = run(['-c', '-i', path.join(tempDir, 'deprecated.html')]);
     assert.strictEqual(status, 1);
   });
 
-  test('Exits “1” when validation errors are found', () => {
+  test('Exits `1` when validation errors are found', () => {
     const { status } = run(['-c', '-i', path.join(tempDir, 'invalid.html')]);
     assert.strictEqual(status, 1);
   });
 
-  test('Exits “0” for clean HTML', () => {
+  test('Exits `0` for clean HTML', () => {
     const { status } = run(['-c', '-i', path.join(tempDir, 'clean.html')]);
     assert.strictEqual(status, 0);
   });
@@ -318,12 +348,12 @@ describe('CLI `--check-links`', () => {
     assert.ok(stdout.includes('broken') || stdout.includes('1'));
   });
 
-  test('Exits “1” with broken links', () => {
+  test('Exits `1` with broken links', () => {
     const { status } = run(['-l', '-i', path.join(tempDir, 'links_refused.html')]);
     assert.strictEqual(status, 1);
   });
 
-  test('Exits “0” when broken links are ignored', () => {
+  test('Exits `0` when broken links are ignored', () => {
     const ignoreDir = path.join(tempDir, 'ignore_test');
     fs.mkdirSync(ignoreDir, { recursive: true });
     fs.writeFileSync(
@@ -358,7 +388,7 @@ describe('CLI `--check-links`', () => {
     fs.rmSync(outDir, { recursive: true, force: true });
   });
 
-  test('`--all` still exits “1” for validation errors (link check does not change gate)', () => {
+  test('`--all` still exits `1` for validation errors (link check does not change gate)', () => {
     // invalid.html has no http/https links, so link check completes quickly before the gate
     const outDir = path.join(tempDir, 'all_links_invalid_out');
     const { status } = run(['-a', '-i', path.join(tempDir, 'invalid.html'), '-o', outDir]);
@@ -433,7 +463,7 @@ describe('CLI `--all`', () => {
     fs.rmSync(outDir, { recursive: true, force: true });
   });
 
-  test('Skips minification and exits “1” when validation errors are found', () => {
+  test('Skips minification and exits `1` when validation errors are found', () => {
     const outDir = path.join(tempDir, 'all_err_out');
     const { stdout, status } = run(['-a', '-i', path.join(tempDir, 'invalid.html'), '-o', outDir]);
     assert.strictEqual(status, 1);
@@ -441,7 +471,7 @@ describe('CLI `--all`', () => {
     assert.ok(!fs.existsSync(path.join(outDir, 'invalid.html')));
   });
 
-  test('Proceeds to minification and exits “0” when all validation errors are ignored via config', async () => {
+  test('Proceeds to minification and exits `0` when all validation errors are ignored via config', async () => {
     const ignoreDir = path.join(tempDir, 'validation_ignore_cli');
     const outDir = path.join(tempDir, 'validation_ignore_cli_out');
     fs.mkdirSync(ignoreDir, { recursive: true });
@@ -464,7 +494,7 @@ describe('CLI `--all`', () => {
     fs.rmSync(outDir, { recursive: true, force: true });
   });
 
-  test('Runs check and minify and exits “0” when only deprecated markup is found (no validation errors)', () => {
+  test('Runs check and minify and exits `0` when only deprecated markup is found (no validation errors)', () => {
     // Uses a11y preset (via config) + `<tt>` element: ObsoHTML flags it, html-validate:a11y does not
     const srcDir = path.join(tempDir, 'all_deprecated_src');
     const outDir = path.join(tempDir, 'all_deprecated_out');
@@ -592,9 +622,22 @@ describe('CLI `--settings`', () => {
     fs.unlinkSync(settingsPath);
   });
 
-  test('Exits "2" when settings file does not exist', () => {
+  // A settings file the user named is theirs to fix, like any other argument
+  test('Exits "1" when settings file does not exist', () => {
     const { status } = run(['-c', '-i', path.join(tempDir, 'clean.html'), '-s', path.join(tempDir, 'nonexistent.json')]);
-    assert.strictEqual(status, 2);
+    assert.strictEqual(status, 1);
+  });
+
+  test('Exits "1" on an unusable setting', () => {
+    const settingsPath = path.join(tempDir, 'bad_setting.json');
+    fs.writeFileSync(settingsPath, JSON.stringify({ links: { concurrency: 'many' } }));
+    try {
+      const { stderr, status } = run(['-c', '-i', path.join(tempDir, 'clean.html'), '-s', settingsPath]);
+      assert.match(stderr, /`links\.concurrency` must be a positive integer/);
+      assert.strictEqual(status, 1);
+    } finally {
+      fs.unlinkSync(settingsPath);
+    }
   });
 });
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "hihtml",
-  "version": "1.5.0",
+  "version": "1.6.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "hihtml",
-      "version": "1.5.0",
+      "version": "1.6.0",
       "license": "MIT",
       "dependencies": {
         "commander": "^15.0.0",

--- a/package.json
+++ b/package.json
@@ -60,5 +60,5 @@
   },
   "type": "module",
   "types": "src/index.d.ts",
-  "version": "1.5.0"
+  "version": "1.6.0"
 }

--- a/src/lib/config.js
+++ b/src/lib/config.js
@@ -5,6 +5,19 @@ import path from 'node:path';
 const CONFIG_FILES = ['hihtml.config.json', '.hihtml.json'];
 
 /**
+ * Marks a failure as the user’s to fix rather than a bug.
+ * @param {string} message
+ * @param {ErrorOptions} [options]
+ * @returns {Error}
+ */
+function setupError(message, options) {
+  const err = new Error(message, options);
+  // @ts-expect-error—marker read by the CLI
+  err.setupFailed = true;
+  return err;
+}
+
+/**
  * @param {unknown} config
  * @param {string} source
  * @returns {asserts config is import('./config.js').HihtmlConfig}
@@ -14,42 +27,42 @@ function validateConfig(config, source) {
   const isStringArray = (/** @type {unknown} */ v) => Array.isArray(v) && v.every(e => typeof e === 'string');
 
   if (c.extensions !== undefined && !isStringArray(c.extensions))
-    throw new Error(`${source}: \`extensions\` must be an array of strings`);
+    throw setupError(`${source}: \`extensions\` must be an array of strings`);
   if (c.ignore !== undefined && !isStringArray(c.ignore))
-    throw new Error(`${source}: \`ignore\` must be an array of strings`);
+    throw setupError(`${source}: \`ignore\` must be an array of strings`);
 
   if (c.validation !== undefined) {
     if (typeof c.validation !== 'object' || c.validation === null || Array.isArray(c.validation))
-      throw new Error(`${source}: \`validation\` must be an object`);
+      throw setupError(`${source}: \`validation\` must be an object`);
     const v = /** @type {Record<string, unknown>} */ (c.validation);
     if (v.preset !== undefined && typeof v.preset !== 'string')
-      throw new Error(`${source}: \`validation.preset\` must be a string`);
+      throw setupError(`${source}: \`validation.preset\` must be a string`);
     if (v.ignore !== undefined && !isStringArray(v.ignore))
-      throw new Error(`${source}: \`validation.ignore\` must be an array of strings`);
+      throw setupError(`${source}: \`validation.ignore\` must be an array of strings`);
   }
 
   if (c.links !== undefined) {
     if (typeof c.links !== 'object' || c.links === null || Array.isArray(c.links))
-      throw new Error(`${source}: \`links\` must be an object`);
+      throw setupError(`${source}: \`links\` must be an object`);
     const l = /** @type {Record<string, unknown>} */ (c.links);
     if (l.timeout !== undefined && (typeof l.timeout !== 'number' || l.timeout <= 0 || !Number.isFinite(l.timeout)))
-      throw new Error(`${source}: \`links.timeout\` must be a positive number`);
+      throw setupError(`${source}: \`links.timeout\` must be a positive number`);
     if (l.concurrency !== undefined && (!Number.isInteger(l.concurrency) || /** @type {number} */ (l.concurrency) < 1))
-      throw new Error(`${source}: \`links.concurrency\` must be a positive integer`);
+      throw setupError(`${source}: \`links.concurrency\` must be a positive integer`);
     if (l.warnOnPermanentRedirects !== undefined && typeof l.warnOnPermanentRedirects !== 'boolean')
-      throw new Error(`${source}: \`links.warnOnPermanentRedirects\` must be a boolean`);
+      throw setupError(`${source}: \`links.warnOnPermanentRedirects\` must be a boolean`);
     if (l.ignore !== undefined && !isStringArray(l.ignore))
-      throw new Error(`${source}: \`links.ignore\` must be an array of strings`);
+      throw setupError(`${source}: \`links.ignore\` must be an array of strings`);
   }
 
   if (c.minification !== undefined) {
     if (typeof c.minification !== 'object' || c.minification === null || Array.isArray(c.minification))
-      throw new Error(`${source}: \`minification\` must be an object`);
+      throw setupError(`${source}: \`minification\` must be an object`);
     const m = /** @type {Record<string, unknown>} */ (c.minification);
     if (m.preset !== undefined && typeof m.preset !== 'string')
-      throw new Error(`${source}: \`minification.preset\` must be a string`);
+      throw setupError(`${source}: \`minification.preset\` must be a string`);
     if (m.options !== undefined && (typeof m.options !== 'object' || m.options === null || Array.isArray(m.options)))
-      throw new Error(`${source}: \`minification.options\` must be an object`);
+      throw setupError(`${source}: \`minification.options\` must be an object`);
   }
 }
 
@@ -77,11 +90,11 @@ async function readConfigFile(cwd, fileName) {
     parsed = JSON.parse(content);
   } catch (err) {
     const nodeErr = /** @type {NodeJS.ErrnoException} */ (err);
-    if (nodeErr.code !== 'ENOENT') throw new Error(`Error reading ${fileName}: ${nodeErr.message}`, { cause: err });
+    if (nodeErr.code !== 'ENOENT') throw setupError(`Error reading ${fileName}: ${nodeErr.message}`, { cause: err });
     return undefined;
   }
   if (parsed === null || typeof parsed !== 'object' || Array.isArray(parsed)) {
-    throw new Error(`${fileName} must contain a JSON object`);
+    throw setupError(`${fileName} must contain a JSON object`);
   }
   validateConfig(parsed, fileName);
   return parsed;
@@ -103,14 +116,14 @@ export async function loadConfig(cwd = process.cwd(), filePath = undefined) {
       const content = await fs.promises.readFile(resolved, 'utf8');
       parsed = JSON.parse(content);
     } catch (err) {
-      throw new Error(`Error reading settings file ${resolved}: ${err instanceof Error ? err.message : String(err)}`, { cause: err });
+      throw setupError(`Error reading settings file ${resolved}: ${err instanceof Error ? err.message : String(err)}`, { cause: err });
     }
     if (parsed === null || typeof parsed !== 'object' || Array.isArray(parsed)) {
-      throw new Error(`Settings file ${resolved} must contain a JSON object`);
+      throw setupError(`Settings file ${resolved} must contain a JSON object`);
     }
     if (parsed.hihtml !== undefined) {
       if (typeof parsed.hihtml !== 'object' || parsed.hihtml === null || Array.isArray(parsed.hihtml)) {
-        throw new Error(`\`hihtml\` key in ${resolved} must be a JSON object`);
+        throw setupError(`\`hihtml\` key in ${resolved} must be a JSON object`);
       }
       validateConfig(parsed.hihtml, resolved);
       return parsed.hihtml;
@@ -131,11 +144,11 @@ export async function loadConfig(cwd = process.cwd(), filePath = undefined) {
     pkg = JSON.parse(content);
   } catch (err) {
     const nodeErr = /** @type {NodeJS.ErrnoException} */ (err);
-    if (nodeErr.code !== 'ENOENT') throw new Error(`Error reading package.json: ${nodeErr.message}`, { cause: err });
+    if (nodeErr.code !== 'ENOENT') throw setupError(`Error reading package.json: ${nodeErr.message}`, { cause: err });
   }
   if (pkg?.hihtml !== undefined) {
     if (typeof pkg.hihtml !== 'object' || pkg.hihtml === null || Array.isArray(pkg.hihtml)) {
-      throw new Error('`hihtml` in package.json must be a JSON object');
+      throw setupError('`hihtml` in package.json must be a JSON object');
     }
     validateConfig(pkg.hihtml, 'package.json');
     return pkg.hihtml;


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * The command-line input argument is now named `path`.
  * Invalid, missing, or unreadable input paths are detected before processing.
* **Bug Fixes**
  * Configuration and runtime failures now return distinct exit statuses: `1` for input or setup errors and `2` for runtime failures.
  * ObsoHTML warnings remain informational and exit successfully with status `0`.
* **Documentation**
  * Updated the README and changelog with the revised input behavior, exit codes, and check-specific results.
* **Release**
  * Version updated to 1.6.0.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->